### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/json-parser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/json-parser

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+$CC $CFLAGS -c rbtree.c -o rbtree.o 
+$CC $CFLAGS -c json_parser.c -o json_parser.o 
+
+# Copy fuzzer executable to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  .clusterfuzzlite/json_parse_fuzzer.c \
+  -o $OUT/json_parse_fuzzer \
+  json_parser.o rbtree.o -I$PWD/

--- a/.clusterfuzzlite/json_parse_fuzzer.c
+++ b/.clusterfuzzlite/json_parse_fuzzer.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <json_parser.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char *new_str = (char *)malloc(size + 1);
+  if (new_str == NULL) {
+    return 0;
+  }
+  memcpy(new_str, data, size);
+  new_str[size] = '\0';
+
+  json_value_t *retval = json_value_parse(new_str);
+  if (retval) {
+    json_value_destroy(retval);
+  }
+
+  free(new_str);
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 180
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `json_value_parse` and currently set the timeout of CFLite to 180 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/json-parser json-parser
cd json-parser
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD json_parse_fuzzer -- -max_total_time=10
```